### PR TITLE
Automation improvement

### DIFF
--- a/deploy_centos_update.sh
+++ b/deploy_centos_update.sh
@@ -20,8 +20,8 @@ SSHUSER="root"
 # ensure it's not an encrypted key or you'll still have to enter a password many many times
 SSHKEY=""
 
-# ping timeout (ms), increase this if distant/slow AMDs fail the test.
-PINGTO=1000
+# ping timeout (s), increase this if distant/slow AMDs fail the test.
+PINGTO=2
 
 # file to deploy.
 DEPLOYPKG="dod_kernel_update.tar.bz2"
@@ -90,7 +90,7 @@ echo -e "$AMDLIST" | while read AMDADDR; do
 
 	# test if AMD is alive
 	echo -e "\nTesting ${AMDADDR}"
-	(ping -W ${PINGTO} -c 4 ${AMDADDR} 2>&1 ) > /dev/nul 
+	(ping -W ${PINGTO} -c 4 ${AMDADDR} 2>&1 ) > /dev/null 
 	ERR=$?
 	if [ $ERR -ne 0 ]; then
 		echo "Couldn't ping AMD ${AMDADDR}. Skipping"
@@ -100,7 +100,7 @@ echo -e "$AMDLIST" | while read AMDADDR; do
 
 	# upload package
 	echo "Uploading to ${AMDADDR}"
-	(${SCP} ${SSHKEY} ${DEPLOYPKG} ${SSHUSER}@${AMDADDR}:/tmp 2>&1) > /dev/nul
+	(${SCP} ${SSHKEY} ${DEPLOYPKG} ${SSHUSER}@${AMDADDR}:/tmp 2>&1) > /dev/null
 	ERR=$?
 	if [ $ERR -ne 0 ]; then
 		echo "Couldn't upload ${DEPLOYPKG} to ${AMDADDR}. Skipping"

--- a/deploy_centos_update.sh
+++ b/deploy_centos_update.sh
@@ -31,6 +31,10 @@ DEPLOYPKG="dod_kernel_update.tar.bz2"
 # "F" freshen packages, will report success if packagaes already up to date, will result in needless reboot of AMD 
 UPDATEFLG="F"
 
+# Additional ssh arguments. This optional argument suppresses manual host authenticity prompt. This occurs when an AMD has not been connected to previously.
+# This can be commented out to suppress this potentially insecure behaviour.
+OPTSSHARGS="-o 'StrictHostKeyChecking no'"
+
 
 
 
@@ -100,7 +104,7 @@ echo -e "$AMDLIST" | while read AMDADDR; do
 
 	# upload package
 	echo "Uploading to ${AMDADDR}"
-	(${SCP} ${SSHKEY} ${DEPLOYPKG} ${SSHUSER}@${AMDADDR}:/tmp 2>&1) > /dev/null
+	(${SCP} ${OPTSSHARGS} ${SSHKEY} ${DEPLOYPKG} ${SSHUSER}@${AMDADDR}:/tmp 2>&1) > /dev/null
 	ERR=$?
 	if [ $ERR -ne 0 ]; then
 		echo "Couldn't upload ${DEPLOYPKG} to ${AMDADDR}. Skipping"
@@ -110,7 +114,7 @@ echo -e "$AMDLIST" | while read AMDADDR; do
 
 	# deploy package
 	echo "Updating ${AMDADDR}"
-	OUTPUT="$(${SSH} ${SSHKEY} -f ${SSHUSER}@${AMDADDR} 'uname -a ; cd /tmp ; tar -xjf /tmp/'${DEPLOYPKG}' && '${SUDO}'rpm -'$UPDATEFLG'i /tmp/centosupdate/*.rpm ; SERR=$? ; echo $SERR ' 2>&1 )"
+	OUTPUT="$(${SSH} ${OPTSSHARGS} ${SSHKEY} -f ${SSHUSER}@${AMDADDR} 'uname -a ; cd /tmp ; tar -xjf /tmp/'${DEPLOYPKG}' && '${SUDO}'rpm -'$UPDATEFLG'i /tmp/centosupdate/*.rpm ; SERR=$? ; echo $SERR ' 2>&1 )"
 	ERR=`echo -e "$OUTPUT" | tail -n 1`
 	if [ $ERR -ne 0 ]; then 
 		# failed or if U flag, already up to date


### PR DESCRIPTION
For each new host the script connects to the user is prompted to verify the authenticity of the connection. This is a break in the automation and should be avoided if possible. 

This PR introduces a new config variable that is used to provide additional arguments to ssh and scp. By default it includes the argument `-o 'StrictHostKeyChecking no'` which should stop ssh (and thus scp) from prompting the user to approve the connection. 

To remove this additional parameter this variable can be commented out.

NB: I'm a scrub and this PR is dirty with the changes I made and included in #1 'pologies